### PR TITLE
支持 Lark 国际版 + post 富文本消息 + 清理事件噪音

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-# 飞书应用凭证（在 https://open.feishu.cn/app 创建应用后获取）
+# 平台选择：feishu（中国版，默认）或 lark（国际版 larksuite.com）
+LARK_PLATFORM=feishu
+
+# 应用凭证
+#   - 飞书：https://open.feishu.cn/app
+#   - Lark：https://open.larksuite.com/app
 FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
 FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/bot_config.py
+++ b/bot_config.py
@@ -7,6 +7,16 @@ load_dotenv()
 FEISHU_APP_ID = os.environ["FEISHU_APP_ID"]
 FEISHU_APP_SECRET = os.environ["FEISHU_APP_SECRET"]
 
+# 平台选择：feishu（中国版，默认）或 lark（国际版）
+_DOMAIN_MAP = {
+    "feishu": "https://open.feishu.cn",
+    "lark": "https://open.larksuite.com",
+}
+LARK_PLATFORM = os.getenv("LARK_PLATFORM", "feishu").lower()
+if LARK_PLATFORM not in _DOMAIN_MAP:
+    raise ValueError(f"LARK_PLATFORM 必须是 feishu 或 lark，当前: {LARK_PLATFORM}")
+LARK_DOMAIN = _DOMAIN_MAP[LARK_PLATFORM]
+
 CLAUDE_CLI = os.getenv("CLAUDE_CLI_PATH") or shutil.which("claude") or "claude"
 
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "claude-opus-4-6")

--- a/feishu_client.py
+++ b/feishu_client.py
@@ -91,10 +91,12 @@ def _card_json(content: str, loading: bool = False) -> str:
 
 
 class FeishuClient:
-    def __init__(self, client: lark.Client, app_id: str = "", app_secret: str = ""):
+    def __init__(self, client: lark.Client, app_id: str = "", app_secret: str = "",
+                 domain: str = "https://open.feishu.cn"):
         self.client = client
         self._app_id = app_id
         self._app_secret = app_secret
+        self._domain = domain.rstrip("/")
 
     async def _retry_with_backoff(self, coro_func, max_retries: int = 3, initial_delay: float = 0.5):
         """
@@ -208,7 +210,7 @@ class FeishuClient:
 
         token_body = json.dumps({"app_id": self._app_id, "app_secret": self._app_secret}).encode()
         token_req = urllib.request.Request(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+            f"{self._domain}/open-apis/auth/v3/tenant_access_token/internal",
             data=token_body,
             headers={"Content-Type": "application/json"},
             method="POST",
@@ -216,7 +218,7 @@ class FeishuClient:
         with urllib.request.urlopen(token_req, context=ctx, timeout=10) as r:
             token = json.loads(r.read())["tenant_access_token"]
 
-        url = f"https://open.feishu.cn/open-apis/im/v1/messages/{message_id}/resources/{image_key}?type=image"
+        url = f"{self._domain}/open-apis/im/v1/messages/{message_id}/resources/{image_key}?type=image"
         img_req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
         tmp_path = os.path.join(tempfile.gettempdir(), f"feishu-img-{uuid.uuid4().hex[:8]}.jpg")
         with urllib.request.urlopen(img_req, context=ctx, timeout=15) as r:

--- a/feishu_post.py
+++ b/feishu_post.py
@@ -1,0 +1,129 @@
+"""
+飞书/Lark post（富文本）消息解析：提取纯文本与图片 image_keys。
+
+参考 codex-tg 项目实现，适配多种 post 包装：
+  1) {"zh_cn": {...}}
+  2) {"post": {"zh_cn": {...}}}
+  3) {"title": "...", "content": [...]}
+"""
+
+import json
+from typing import Any
+
+
+def _flatten_post_block(node: Any) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if isinstance(node, list):
+        if not node:
+            return ""
+        # content 通常是 [[block, block, ...], [block, ...]]（行列表）
+        if all(isinstance(x, list) for x in node):
+            lines = []
+            for line in node:
+                line_text = "".join(_flatten_post_block(p) for p in line).strip()
+                if line_text:
+                    lines.append(line_text)
+            return "\n".join(lines)
+        return "".join(_flatten_post_block(x) for x in node)
+    if isinstance(node, dict):
+        tag = str(node.get("tag") or "").lower()
+        if tag == "text":
+            return str(node.get("text") or "")
+        if tag == "a":
+            return str(node.get("text") or node.get("href") or "")
+        if tag == "at":
+            return str(node.get("user_name") or node.get("name") or "")
+        if tag in ("img", "media"):
+            return "[图片]"
+        return "".join(_flatten_post_block(v) for v in node.values())
+    return ""
+
+
+def parse_post_content(raw: str | None) -> str:
+    """提取 post 消息的纯文本（title + 扁平化 content）"""
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+
+    locale_payload: dict[str, Any] = {}
+    roots: list[dict[str, Any]] = [parsed]
+    for key in ("post", "data"):
+        nested = parsed.get(key)
+        if isinstance(nested, dict):
+            roots.append(nested)
+
+    for root in roots:
+        for loc in ("zh_cn", "en_us", "ja_jp"):
+            if isinstance(root.get(loc), dict):
+                locale_payload = root[loc]
+                break
+        if locale_payload:
+            break
+        if "content" in root or "title" in root:
+            locale_payload = root
+            break
+
+    if not locale_payload:
+        return ""
+
+    title = str(locale_payload.get("title") or "").strip()
+    content_node = locale_payload.get("content")
+    if isinstance(content_node, str):
+        try:
+            content_node = json.loads(content_node)
+        except json.JSONDecodeError:
+            pass
+
+    body = _flatten_post_block(content_node).strip()
+    if not body:
+        body = _flatten_post_block(locale_payload).strip()
+
+    if title and body:
+        return f"{title}\n{body}"
+    return title or body
+
+
+def _collect_image_keys(node: Any, keys: list[str]) -> None:
+    if node is None:
+        return
+    if isinstance(node, list):
+        for item in node:
+            _collect_image_keys(item, keys)
+        return
+    if isinstance(node, dict):
+        tag = str(node.get("tag") or "").lower()
+        if tag in ("img", "media"):
+            key = (node.get("image_key") or "").strip()
+            if key:
+                keys.append(key)
+            return
+        for v in node.values():
+            if isinstance(v, (list, dict)):
+                _collect_image_keys(v, keys)
+
+
+def extract_post_image_keys(raw: str | None) -> list[str]:
+    """递归收集 post 内的所有 image_key（按出现顺序，去重保留首次）"""
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    keys: list[str] = []
+    _collect_image_keys(parsed, keys)
+    seen = set()
+    result = []
+    for k in keys:
+        if k not in seen:
+            seen.add(k)
+            result.append(k)
+    return result

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from lark_oapi.event.callback.model.p2_card_action_trigger import (
 
 import bot_config as config
 from feishu_client import FeishuClient
+from feishu_post import parse_post_content, extract_post_image_keys
 from session_store import SessionStore, generate_summary, _write_custom_title
 from commands import parse_command, handle_command
 from claude_runner import run_claude
@@ -68,10 +69,16 @@ threading.Thread(target=_start_bot_loop, daemon=True, name="bot-loop").start()
 lark_client = lark.Client.builder() \
     .app_id(config.FEISHU_APP_ID) \
     .app_secret(config.FEISHU_APP_SECRET) \
+    .domain(config.LARK_DOMAIN) \
     .log_level(lark.LogLevel.INFO) \
     .build()
 
-feishu = FeishuClient(lark_client, app_id=config.FEISHU_APP_ID, app_secret=config.FEISHU_APP_SECRET)
+feishu = FeishuClient(
+    lark_client,
+    app_id=config.FEISHU_APP_ID,
+    app_secret=config.FEISHU_APP_SECRET,
+    domain=config.LARK_DOMAIN,
+)
 store = SessionStore()
 _active_runs = ActiveRunRegistry()
 
@@ -476,6 +483,44 @@ async def _process_message(user_id: str, chat_id: str, is_group: bool, msg):
             else:
                 await feishu.send_text_to_user(user_id, f"❌ 下载图片失败：{e}")
             return
+
+    elif msg.message_type == "post":
+        post_text = parse_post_content(msg.content).strip()
+        image_keys = extract_post_image_keys(msg.content)
+
+        # 群聊去掉 @mention 占位符（post 文本里也可能混入）
+        if is_group:
+            for mention in (getattr(msg, 'mentions', None) or []):
+                key = getattr(mention, 'key', '')
+                if key:
+                    post_text = post_text.replace(key, '').strip()
+
+        img_paths: list[str] = []
+        for ik in image_keys:
+            try:
+                path = await feishu.download_image(msg.message_id, ik)
+                img_paths.append(path)
+            except Exception as e:
+                print(f"[error] 下载 post 图片失败 key={ik[:8]}...: {e}", flush=True)
+
+        if not post_text and not img_paths:
+            print(f"[post] 空内容，忽略", flush=True)
+            return
+
+        if img_paths:
+            paths_list = "\n".join(f"  - {p}" for p in img_paths)
+            caption = post_text or "（无文字说明）"
+            text = (
+                f"[用户发送了富文本消息，含 {len(img_paths)} 张图片]\n"
+                f"文字内容：{caption}\n"
+                f"图片路径：\n{paths_list}\n"
+                f"请读取并分析这些图片，结合文字回复（中文）。"
+            )
+            img_path = img_paths[0]  # 仅用于日志兼容
+        else:
+            text = post_text
+
+        print(f"[post] text_len={len(post_text)} imgs={len(img_paths)}", flush=True)
 
     else:
         return  # 不支持的消息类型
@@ -1001,6 +1046,7 @@ def _start_ngrok(port):
 
 def main():
     print("🚀 飞书 Claude Bot 启动中...")
+    print(f"   平台        : {config.LARK_PLATFORM} ({config.LARK_DOMAIN})")
     print(f"   App ID      : {config.FEISHU_APP_ID}")
     print(f"   默认模型    : {config.DEFAULT_MODEL}")
     print(f"   默认工作目录: {config.DEFAULT_CWD}")
@@ -1018,12 +1064,14 @@ def main():
     handler = lark.EventDispatcherHandler.builder("", "") \
         .register_p2_im_message_receive_v1(on_message_receive) \
         .register_p2_card_action_trigger(on_card_action) \
+        .register_p2_im_message_message_read_v1(lambda _e: None) \
         .build()
 
     ws_client = lark.ws.Client(
         config.FEISHU_APP_ID,
         config.FEISHU_APP_SECRET,
         event_handler=handler,
+        domain=config.LARK_DOMAIN,
         log_level=lark.LogLevel.INFO,
     )
 


### PR DESCRIPTION
## Summary

- **Lark 国际版支持**：新增 `LARK_PLATFORM` 环境变量（`feishu` / `lark`），派生 `LARK_DOMAIN`；`Client.builder`、`ws.Client`、`FeishuClient` 的 token / 图片下载 URL 统一走配置域名。默认行为保持不变（feishu）。
- **post 富文本消息**：新增 `feishu_post.py`，递归解析 post 的 `title + content` 文字和所有 `image_key`；`main.py` 在 `image` 分支后增加 `post` 分支，批量下载图片并把路径拼入 prompt 交给 Claude 读图分析。修复了之前发带图的富文本消息会被静默忽略的问题。
- **事件噪音清理**：为 `im.message.message_read_v1`（已读回执）注册空 handler，消除日志里的 `processor not found` ERROR 刷屏。
- 启动横幅打印当前平台 + 域名，方便确认部署环境。

## 兼容性

- 默认 `LARK_PLATFORM=feishu`，不设置时行为与旧版完全一致。
- `FeishuClient.__init__` 的 `domain` 参数有默认值 `https://open.feishu.cn`，现有调用点无需修改。
- post 解析兼容三种客户端包装：`{zh_cn: {...}}` / `{post: {zh_cn: {...}}}` / `{title, content}`，以及 `content` 被编码成 JSON 字符串的情况。

## Test plan

- [x] 本地单元验证：`feishu_post.parse_post_content` / `extract_post_image_keys` 对三种 wrapper + 空输入的预期输出
- [x] `LARK_PLATFORM=lark` 启动，WS 实际连到 `msg-frontier-sg.larksuite.com`
- [x] 真实 Lark 国际版环境下私聊发送带图 post 消息，图片下载 → Claude 读图 → 卡片回复全流程通过
- [x] `message_read_v1` ERROR 消失
- [ ] 待验证：中国版飞书回归测试（理论无影响，因为默认域名不变）
- [ ] 待验证：群聊 post @mention 去除

## 备注

发送方来自 Claude Code 协作 session，commit footer 已标注 Co-Authored-By。如果希望拆成两个 PR（Lark i18n 和 post 支持），也可以。