### PR TITLE
feat: support AskUserQuestion interactive buttons in Lark cards

### DIFF
--- a/claude_runner.py
+++ b/claude_runner.py
@@ -168,11 +168,13 @@ async def run_claude(
                             await _fire_callback(on_tool_use, pending_tool_name, {})
 
                     elif evt_type == "content_block_stop":
-                        if pending_tool_name and pending_tool_input_json:
-                            try:
-                                inp = json.loads(pending_tool_input_json)
-                            except json.JSONDecodeError:
-                                inp = {}
+                        if pending_tool_name:
+                            inp = {}
+                            if pending_tool_input_json:
+                                try:
+                                    inp = json.loads(pending_tool_input_json)
+                                except json.JSONDecodeError:
+                                    pass
                             await _fire_callback(on_tool_use, pending_tool_name, inp)
                         pending_tool_name = ""
                         pending_tool_input_json = ""

--- a/main.py
+++ b/main.py
@@ -285,7 +285,15 @@ async def _run_and_display(
         if push_failures >= 3:
             return
         try:
-            await feishu.update_card(card_msg_id, content)
+            if ask_options:
+                buttons = [
+                    {"text": display, "value": {"reply": value, "cid": chat_id}}
+                    for display, value in ask_options
+                ]
+                short = all(len(b["text"]) <= 10 for b in buttons)
+                await feishu.update_card_with_buttons(card_msg_id, content, buttons, flow=short)
+            else:
+                await feishu.update_card(card_msg_id, content)
             push_failures = 0
         except Exception as push_err:
             push_failures += 1
@@ -323,15 +331,41 @@ async def _run_and_display(
             print(f"[Worktree] 退出 worktree", flush=True)
             return
         if name.lower() == "askuserquestion":
-            question = inp.get("question", inp.get("text", ""))
-            if question:
-                accumulated += f"\n\n❓ **等待回复：**\n{question}"
-                detected = _extract_options(question)
-                if detected:
+            questions = inp.get("questions", [])
+            if questions:
+                parts = []
+                opts = []
+                multi = len(questions) > 1
+                for q in questions:
+                    header = q.get("header", "")
+                    qtext = q.get("question", "")
+                    if header:
+                        parts.append(f"**{header}**: {qtext}" if qtext else f"**{header}**")
+                    elif qtext:
+                        parts.append(qtext)
+                    for opt in q.get("options", []):
+                        label = opt.get("label", "")
+                        desc = opt.get("description", "")
+                        if label:
+                            btn_text = f"[{header}] {label}" if multi and header else label
+                            opts.append((btn_text, btn_text))
+                            if desc:
+                                parts.append(f"  • **{label}** — {desc}")
+                if parts:
+                    accumulated += "\n\n❓ **等待回复：**\n" + "\n".join(parts)
+                if opts:
                     ask_options.clear()
-                    ask_options.extend(detected)
-                await push(_build_display())
-                return
+                    ask_options.extend(opts)
+            else:
+                question = inp.get("question", inp.get("text", ""))
+                if question:
+                    accumulated += f"\n\n❓ **等待回复：**\n{question}"
+                    detected = _extract_options(question)
+                    if detected:
+                        ask_options.clear()
+                        ask_options.extend(detected)
+            await push(_build_display())
+            return
         tool_line = _format_tool(name, inp)
         if inp and tool_history:
             tool_history[-1] = tool_line


### PR DESCRIPTION
## Summary

When Claude Code calls `AskUserQuestion` in `--print` mode (which is the standard mode for this integration), the tool errors because there is no interactive terminal. Previously, users in Lark never saw the question or options — the tool silently failed.

This PR makes `AskUserQuestion` work end-to-end through Lark card buttons:

- **Parse structured `questions` format**: Handle the `{questions: [{header, question, options: [{label, description}]}]}` input that Claude Code actually sends, instead of only the legacy flat `{question: "..."}` format
- **Render options as clickable buttons**: Detected options become Lark card buttons. User clicks → selection sent back to Claude as a new message → Claude continues the workflow
- **Preserve buttons during streaming**: `push()` now includes buttons when `ask_options` is populated, preventing intermediate `on_text_chunk` updates from overwriting them
- **Fix `content_block_stop` callback**: Always fire `on_tool_use` at `content_block_stop` even when `input_json` is empty, ensuring no tool calls are silently dropped

## How it works

```
Claude calls AskUserQuestion
  → stream-json emits tool_use events
  → on_tool_use() extracts questions & options
  → push() renders Lark card with clickable buttons
  → User clicks a button
  → WebSocket callback triggers _handle_button_reply()
  → Selection sent to Claude as new message
  → Claude continues workflow
```

Supports: single-question, multi-question (with `[Header]` prefixed buttons), and Y/N fallback patterns.

## Test plan

- [x] Tested with skill consent flow (single question, 2 options)
- [x] Verified buttons render correctly in Lark card
- [x] Verified button click callback works via WebSocket (no ngrok needed)
- [x] Verified Claude receives the selection and continues processing
- [x] Backward compatible: legacy text-based option detection still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)