### PR TITLE
fix: deduplicate duplicate messages from Feishu WebSocket

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,6 +79,10 @@ _active_runs = ActiveRunRegistry()
 _chat_locks: dict[str, asyncio.Lock] = {}
 _MAX_CHAT_LOCKS = 200  # 防止无界增长
 
+# 消息去重：飞书 WebSocket 偶尔会推送重复消息
+_processed_msg_ids: set[str] = set()
+_MAX_PROCESSED_IDS = 2000  # 防止内存无限增长
+
 
 # ── /stop 命令处理 ───────────────────────────────────────────
 
@@ -779,6 +783,16 @@ def on_message_receive(data: P2ImMessageReceiveV1) -> None:
     """飞书 SDK 同步回调，调度异步任务到 _bot_loop。"""
     global _last_event
     _last_event = time.time()
+
+    # 消息去重：飞书 WebSocket 偶尔推送重复消息
+    msg_id = data.event.message.message_id
+    if msg_id in _processed_msg_ids:
+        print(f"[去重] 跳过重复消息 msg_id={msg_id}", flush=True)
+        return
+    _processed_msg_ids.add(msg_id)
+    if len(_processed_msg_ids) > _MAX_PROCESSED_IDS:
+        _processed_msg_ids.clear()
+
     asyncio.run_coroutine_threadsafe(handle_message_async(data), _bot_loop)
 
 


### PR DESCRIPTION
## 问题

飞书 WebSocket 偶尔会因网络波动推送重复消息，导致同一条用户消息被 Claude 处理两次。

## 改动

在 `on_message_receive` 同步回调层拦截重复 `msg_id`，避免重复触发 `handle_message_async`。

- 使用 `_processed_msg_ids` 集合跟踪已处理的消息 ID
- 集合上限 2000 条自动清空，防止内存泄漏
- 重复消息打印 `[去重]` 日志便于排查

## 测试

已在本地运行数小时，重复消息被正确拦截。