### PR TITLE
fix: resume 失效会话时自动退回新 session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.test
 .venv/
+venv/
 __pycache__/
 *.pyc
 *.egg-info/

--- a/claude_runner.py
+++ b/claude_runner.py
@@ -196,10 +196,18 @@ async def run_claude(
     final_text, new_session_id, returncode, stderr_text = await _run_once(session_id)
     used_fresh_session_fallback = False
 
-    # Claude 的 session 与 cwd 不兼容时，CLI 有时直接 code=1 且 stderr 为空。
-    # 这种场景自动退回新 session，避免用户必须手动 /new。
-    if session_id and returncode != 0 and not stderr_text and not final_text:
-        print("[run_claude] resume failed without stderr, retrying with fresh session", flush=True)
+    # 旧 session 无法 resume 时自动退回新 session，避免用户必须手动 /new。
+    # 两种典型情况：
+    #   1. session 与 cwd 不兼容时，CLI 有时直接 code=1 且 stderr 为空；
+    #   2. session 文件已被删除/过期，CLI 报 "No conversation found with session ID"。
+    resume_failed = session_id and returncode != 0 and not final_text and (
+        not stderr_text or "No conversation found" in stderr_text
+    )
+    if resume_failed:
+        print(
+            f"[run_claude] resume failed (stderr={stderr_text!r}), retrying with fresh session",
+            flush=True,
+        )
         final_text, new_session_id, returncode, stderr_text = await _run_once(None)
         used_fresh_session_fallback = True
 

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -134,6 +134,31 @@ def test_run_claude_retries_without_resume_on_empty_stderr_failure(monkeypatch):
     assert second.stdin.closed is True
 
 
+def test_run_claude_retries_without_resume_on_no_conversation_found(monkeypatch):
+    """session 已被删除/过期时，CLI 报 'No conversation found'，应自动退回新 session"""
+    first = FakeProc(
+        [],
+        stderr=b"No conversation found with session ID: sid_old",
+        returncode=1,
+    )
+    second = FakeProc([
+        b'{"type":"system","session_id":"sid_new"}\n',
+        b'{"type":"result","session_id":"sid_new","result":"fresh answer"}\n',
+    ])
+    procs = iter([first, second])
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return next(procs)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    text, session_id, used_fallback = asyncio.run(run_claude("hi", session_id="sid_old"))
+
+    assert text == "fresh answer"
+    assert session_id == "sid_new"
+    assert used_fallback is True
+
+
 def test_run_claude_streams_text_chunks_via_callback(monkeypatch):
     """Test that on_text_chunk callback fires for text deltas"""
     proc = FakeProc([


### PR DESCRIPTION
## 问题

当旧 session 文件被删除/过期时，`claude` CLI 会报
`No conversation found with session ID: ...` 并以 code 1 退出，错误写入 stderr。

原有的「resume 失败自动退回新 session」兜底逻辑仅在 **stderr 为空** 时触发
(`claude_runner.py`)，因此「会话过期」这个最常见的场景被漏掉，直接把
`RuntimeError` 抛给了用户，用户只能手动 `/new`。

## 改动

扩展兜底触发条件：当 stderr 包含 `"No conversation found"` 时同样退回新
session，用户会看到自动切换提示而非红色报错。

## 测试

新增单测 `test_run_claude_retries_without_resume_on_no_conversation_found`
覆盖该场景。本地 `pytest tests/test_claude_runner.py` 全部通过（7 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)